### PR TITLE
fixes linking issue due to missing z lib: compress2/uncompress

### DIFF
--- a/src/libfrsm/CMakeLists.txt
+++ b/src/libfrsm/CMakeLists.txt
@@ -2,7 +2,7 @@ file(GLOB cpp_files *.cpp)
 file(GLOB hpp_files *.h*)
 add_library(frsm SHARED ${cpp_files})
 
-set(REQUIRED_LIBS ${IPP_LIBS})
+set(REQUIRED_LIBS ${IPP_LIBS} z)
 
 set(REQUIRED_PKGS glib-2.0)
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
this allows frsm to build without zlib. Previously it failed on frsm-test
... but maybe your preference is to skip the test in this case?

Spotted by @patmarion: 
If I do a clean build of externals, and start by building frsm, then I get:

Linking CXX executable ../../../bin/frsm-test
/home/user/drc/software/externals/frsm/pod-build/lib/libfrsm.so: undefined reference to `compress2'
/home/user/drc/software/externals/frsm/pod-build/lib/libfrsm.so: undefined reference to`uncompress'

But if I let libbot build first, then cd frsm && make clean && make, then it works.
So it looks like frsm is perhaps resolving the link error with zlib indirectly when it uses libbot.
